### PR TITLE
Create formatter git hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+    -   id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,4 @@ repos:
     rev: 19.3b0
     hooks:
     -   id: black
+        language_version: python3.7

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ cd pyplanedev/
 git clone https://github.com/m-squared96/PyPLANE
 source bin/activate
 pip install -r PyPLANE/requirements.txt
+pre-commit install
 ```
 
 Note that all Python code should be formatted using the Black Python code formatter. Information can be found on the

--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ pip install -r PyPLANE/requirements.txt
 pre-commit install
 ```
 
-Note that all Python code should be formatted using the Black Python code formatter. Information can be found on the
-project's GitHub page: https://github.com/psf/black
+Note that all Python code should be formatted using the Black Python code formatter. This is achieved automatically
+through the use of pre-commit hooks.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sympy==1.4
 scipy==1.3.1
 matplotlib==3.1.1
 PyQt5==5.13.0
+pre-commit==1.18.3

--- a/source/test-black-git-hook.py
+++ b/source/test-black-git-hook.py
@@ -1,0 +1,20 @@
+# just used to test that the Black formatter git hook works as expected.
+# This is not part of the main source code of the project.
+
+# Before formatting:
+# a=1
+# b = [1, 2, 3,
+#      4, 5
+#      ]
+
+# if a==0: print('a is 0')
+# else: print('a is 1')
+
+
+a = 1
+b = [1, 2, 3, 4, 5]
+
+if a == 0:
+    print("a is 0")
+else:
+    print("a is 1")


### PR DESCRIPTION
## What is this change?

in this branch, the Black formatter now runs on the project's source code when a commit has been launched. If any formatting is done, this fact is printed to the console and the commit is aborted, as shown below.

![pre-commit-formatting-example](https://user-images.githubusercontent.com/40291100/64908407-c9a7e300-d6f7-11e9-89ec-a7b9b3abdb9f.png)

This allows you to review the files that have been formatted. The next time you enter a git commit command (assuming that you haven't changed anything in the meantime) there should be no files to be formatted, since this has been done already, and the commit will go ahead. 

This functionality was enabled by the "pre-commit" framework, which allows for the easy creation of git hooks (executable code that runs before some significant git-related action) that run right before a commit is finalised. Instructions for the developer that set up the git hook have been added to the README file.

A test file named test-black-git-hook.py has been created, which was created to test and to demonstrate the hook's functionality. This file should be removed before this branch is merged.