### PR TITLE
Iss44 lsoda errors - choose solver method by GUI menu

### DIFF
--- a/source/equations.py
+++ b/source/equations.py
@@ -160,7 +160,9 @@ class SystemOfEquations:
 
     def solve(self, t_span, r0, method=None):
         method = method if method is not None else self.solve_method
-        return solve_ivp(self.phasespace_eval, t_span, r0, method=method, max_step=0.02)
+        return solve_ivp(
+            self.phasespace_eval, t_span, r0, method=method, max_step=0.005
+        )
 
     def phasespace_eval(self, t, r) -> tuple:
         """

--- a/source/equations.py
+++ b/source/equations.py
@@ -117,7 +117,7 @@ class SystemOfEquations:
         # calculated fixed points are cached here
         self.fixed_points = self.calc_fixed_points()
 
-        self.valid_solve_methods = {"RK45", "RK23", "DOP853", "Radau", "BDF", "LSODA"}
+        self.valid_solve_methods = ["RK45", "RK23", "DOP853", "Radau", "BDF", "LSODA"]
         self.set_solve_method("RK45")
 
     def __str__(self) -> str:

--- a/source/equations.py
+++ b/source/equations.py
@@ -117,6 +117,7 @@ class SystemOfEquations:
         # calculated fixed points are cached here
         self.fixed_points = self.calc_fixed_points()
 
+        self.valid_solve_methods = {"RK45", "RK23", "DOP853", "Radau", "BDF", "LSODA"}
         self.set_solve_method("RK45")
 
     def __str__(self) -> str:
@@ -139,10 +140,11 @@ class SystemOfEquations:
         https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.solve_ivp.html
         """
 
-        valid_methods = {"RK45", "RK23", "DOP853", "Radau", "BDF", "LSODA"}
-        if method not in valid_methods:
+        if method not in self.valid_solve_methods:
             raise ValueError(
-                "Solver method must be one of the following: {}".format(valid_methods)
+                "Solver method must be one of the following: {}".format(
+                    self.valid_solve_methods
+                )
             )
         else:
             self.solve_method = method

--- a/source/equations.py
+++ b/source/equations.py
@@ -84,7 +84,13 @@ class SystemOfEquations:
     """
 
     def __init__(
-        self, system_coords, ode_expr_strings, params=None, *args, **kwargs
+        self,
+        system_coords,
+        ode_expr_strings,
+        params=None,
+        solve_method="LSODA",
+        *args,
+        **kwargs,
     ) -> None:
         # ode_expr_strings is a dictionary that maps the dependent variable
         # of the equation (e.g. x in dx/dt = f(x,t)) to the corresponding
@@ -118,7 +124,7 @@ class SystemOfEquations:
         self.fixed_points = self.calc_fixed_points()
 
         self.valid_solve_methods = ["RK45", "RK23", "DOP853", "Radau", "BDF", "LSODA"]
-        self.set_solve_method("RK45")
+        self.set_solve_method(solve_method)
 
     def __str__(self) -> str:
         return f"{self.__repr__()}" + "\n".join(f"{eqn}" for eqn in self.equations)

--- a/source/equations.py
+++ b/source/equations.py
@@ -60,8 +60,6 @@ class DifferentialEquation:
             [self.indep_var, self.phase_coords, *self.params], self.expr
         )
 
-        self.set_solve_method("RK45")
-
     def set_param(self, param, value) -> None:
         """
         Sets self.param_values[param] to value.
@@ -118,6 +116,8 @@ class SystemOfEquations:
 
         # calculated fixed points are cached here
         self.fixed_points = self.calc_fixed_points()
+
+        self.set_solve_method("RK45")
 
     def __str__(self) -> str:
         return f"{self.__repr__()}" + "\n".join(f"{eqn}" for eqn in self.equations)

--- a/source/equations.py
+++ b/source/equations.py
@@ -60,6 +60,8 @@ class DifferentialEquation:
             [self.indep_var, self.phase_coords, *self.params], self.expr
         )
 
+        self.set_solve_method("RK45")
+
     def set_param(self, param, value) -> None:
         """
         Sets self.param_values[param] to value.
@@ -120,7 +122,33 @@ class SystemOfEquations:
     def __str__(self) -> str:
         return f"{self.__repr__()}" + "\n".join(f"{eqn}" for eqn in self.equations)
 
-    def solve(self, t_span, r0, method="LSODA"):
+    def set_solve_method(self, method: str):
+        """
+        Sets the method for solving the system of ODEs.
+
+        The solver method can be one of the following:
+        RK45   - Explicit Runge-Kutta method of order 5(4).
+        RK23   - Explicit Runge-Kutta method of order 3(2).
+        DOP853 - Explicit Runge-Kutta method of order 8.
+        Radau  - Implicit Runge-Kutta method of the Radau IIA family of order 5
+        BDF    - Implicit multi-step variable-order (1 to 5) method based on a
+                 backward differentiation formula for the derivative approximation.
+        LSODA - Adams/BDF method with automatic stiffness detection and switching.
+
+        For more information, see the solve_ivp documentation:
+        https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.solve_ivp.html
+        """
+
+        valid_methods = {"RK45", "RK23", "DOP853", "Radau", "BDF", "LSODA"}
+        if method not in valid_methods:
+            raise ValueError(
+                "Solver method must be one of the following: {}".format(valid_methods)
+            )
+        else:
+            self.solve_method = method
+
+    def solve(self, t_span, r0, method=None):
+        method = method if method is not None else self.solve_method
         return solve_ivp(self.phasespace_eval, t_span, r0, method=method, max_step=0.02)
 
     def phasespace_eval(self, t, r) -> tuple:

--- a/source/equations.py
+++ b/source/equations.py
@@ -121,7 +121,10 @@ class SystemOfEquations:
         # print(f"Jacobian: {self.jac}")
 
         # calculated fixed points are cached here
-        self.fixed_points = self.calc_fixed_points()
+        try:
+            self.fixed_points = self.calc_fixed_points()
+        except:
+            print("Could not symbolically calculate fixed points.")
 
         self.valid_solve_methods = ["RK45", "RK23", "DOP853", "Radau", "BDF", "LSODA"]
         self.set_solve_method(solve_method)

--- a/source/ui_main_window.py
+++ b/source/ui_main_window.py
@@ -13,6 +13,9 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QAction,
+    QWidgetAction,
+    QComboBox,
+    QMenu,
 )
 
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
@@ -72,6 +75,17 @@ class MainWindow(QMainWindow):
         self.action_fixed_points = QAction("Show Fixed Points", self, checkable=True)
         menu_edit.addAction(self.action_fixed_points)
         self.action_fixed_points.changed.connect(self.phase_plot.toggle_fixed_points)
+
+        # Edit > Select Solver Method
+        self.solve_method_combo = QComboBox(self)
+        for method in self.phase_plot.system.valid_solve_methods:
+            self.solve_method_combo.addItem(method)
+        self.solve_method_list = QWidgetAction(None)
+        self.solve_method_list.setDefaultWidget(self.solve_method_combo)
+
+        self.solve_method_menu = QMenu("Solver Method", self)
+        self.solve_method_menu.addAction(self.solve_method_list)
+        menu_edit.addMenu(self.solve_method_menu)
 
     def setup_equation_inputs(self) -> None:
         """
@@ -345,7 +359,7 @@ class MainWindow(QMainWindow):
         return False
 
     def params_undefined(
-        self, dep_var: str, phase_coords: list, ode_str: str, passed_params: dict,
+        self, dep_var: str, phase_coords: list, ode_str: str, passed_params: dict
     ) -> bool:
         """
         Checks for undefined parameters in ODE expressions.

--- a/source/ui_main_window.py
+++ b/source/ui_main_window.py
@@ -80,12 +80,16 @@ class MainWindow(QMainWindow):
         self.solve_method_combo = QComboBox(self)
         for method in self.phase_plot.system.valid_solve_methods:
             self.solve_method_combo.addItem(method)
+        self.solve_method_combo.setCurrentText(self.phase_plot.system.solve_method)
+        self.solve_method = self.phase_plot.system.solve_method
+
         self.solve_method_list = QWidgetAction(None)
         self.solve_method_list.setDefaultWidget(self.solve_method_combo)
 
         self.solve_method_menu = QMenu("Solver Method", self)
         self.solve_method_menu.addAction(self.solve_method_list)
         menu_edit.addMenu(self.solve_method_menu)
+        self.solve_method_combo.currentIndexChanged.connect(self.solve_method_changed)
 
     def setup_equation_inputs(self) -> None:
         """
@@ -306,6 +310,10 @@ class MainWindow(QMainWindow):
         else:
             self.handle_empty_entry(phase_coords, passed_params)
 
+    def solve_method_changed(self):
+        self.solve_method = self.solve_method_combo.currentText()
+        self.phase_plot.system.set_solve_method(self.solve_method)
+
     def update_psp(self, phase_coords: list, passed_params: dict) -> None:
         """
         Gathers entry information from GUI and updates phase plot
@@ -314,7 +322,9 @@ class MainWindow(QMainWindow):
         f_2 = self.y_prime_entry.text()
         eqns = [f_1, f_2]
 
-        system_of_eqns = SystemOfEquations(phase_coords, eqns, params=passed_params)
+        system_of_eqns = SystemOfEquations(
+            phase_coords, eqns, params=passed_params, solve_method=self.solve_method
+        )
 
         self.action_nullclines.setChecked(False)
 


### PR DESCRIPTION
This branch adds:
* An option in the SystemOfEquations class to choose the system solver method used to calculate initial-value problems, i.e. paths in phase space
* A GUI menu to use the above feature

While I was at it, I handled the NotImplementedError thrown by sympy.solve when it does not have an algorithm to analytically solve a system. The sympy.solve function is called in calc_fixed_points.

This branch does not directly address the issue that the LSODA method freezes the app for some systems of equations, but it presents a simple way of changing the solver method to circumvent the issue.