### PR TITLE
Reoved specific version numbers from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy==1.17.0
-sympy==1.4
-scipy==1.3.1
-matplotlib==3.1.1
-PyQt5==5.13.0
-pre-commit==1.18.3
+numpy
+sympy
+scipy
+matplotlib
+PyQt5
+pre-commit


### PR DESCRIPTION
As explained in #68, these versions are rather old, and pip `pip install -r requirements.txt` fails. 